### PR TITLE
Create list get

### DIFF
--- a/Objects/clinic/listobject.c.h
+++ b/Objects/clinic/listobject.c.h
@@ -2,6 +2,24 @@
 preserve
 [clinic start generated code]*/
 
+PyDoc_STRVAR(list_get__doc__,
+"get($self, index, alternate, /)\n"
+"--\n"
+"\n"
+"Get object at index or alternate value.");
+
+#define LIST_GET_METHODDEF      \
+    {"get", (PyCFunction)(void(*)(void))list_get, METH_FASTCALL, list_get__doc__},
+
+static PyObject *
+list_get_impl(PyListObject *self, PyObject* item, PyObject* alt);
+
+static PyObject *
+list_get(PyListObject* self, PyObject *const *args, Py_ssize_t nargs)
+{
+    return list_get_impl(self, args[0], nargs <= 1 ? NULL : args[1]);
+}
+
 PyDoc_STRVAR(list_insert__doc__,
 "insert($self, index, object, /)\n"
 "--\n"

--- a/Objects/listobject.c
+++ b/Objects/listobject.c
@@ -2790,6 +2790,7 @@ static PyMethodDef list_methods[] = {
     LIST_COUNT_METHODDEF
     LIST_REVERSE_METHODDEF
     LIST_SORT_METHODDEF
+    LIST_GET_METHODDEF
     {"__class_getitem__", (PyCFunction)Py_GenericAlias, METH_O|METH_CLASS, PyDoc_STR("See PEP 585")},
     {NULL,              NULL}           /* sentinel */
 };

--- a/Objects/listobject.c
+++ b/Objects/listobject.c
@@ -2816,9 +2816,9 @@ list_get_impl(PyListObject* self, PyObject* item, PyObject* alt)
         return NULL;
     }
 
-    PyObject* result = list_item(self, i);
-    if (result == NULL) return alt;
-    return result;
+    if (!valid_index(i, Py_SIZE(self))) return alt;
+    Py_IncRef(self->ob_item[i]);
+    return self->ob_item[i];
 }
 
 static PyObject *

--- a/Objects/listobject.c
+++ b/Objects/listobject.c
@@ -2808,6 +2808,19 @@ static PySequenceMethods list_as_sequence = {
 };
 
 static PyObject *
+list_get_impl(PyListObject* self, PyObject* item, PyObject* alt)
+{
+    Py_ssize_t i = PyNumber_AsSsize_t(item, PyExc_IndexError);
+    if (i == -1 && PyErr_Occurred()) {
+        return NULL;
+    }
+
+    PyObject* result = list_item(self, i);
+    if (result == NULL) return alt;
+    return result;
+}
+
+static PyObject *
 list_subscript(PyListObject* self, PyObject* item)
 {
     if (_PyIndex_Check(item)) {


### PR DESCRIPTION
This is the first small feature I've wanted in Python for a while - just like I can get an item or an alternate with a dictionary:
```
my_dict = {'test': 'value'}
my_dict.get('not_there', None)
```
I want to do the same with a list:
```
my_list = [1, 2, 3]
my_list.get(10, None)
```

Those pesky index errors are just a pain.
